### PR TITLE
In case of "search", there's no page_title

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "robbrazier/piwik",
+    "name": "katzefudder/piwik",
     "description": "Piwik Package for Laravel",
     "license": "MIT",
     "version": "2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "katzefudder/piwik",
+    "name": "robbrazier/piwik",
     "description": "Piwik Package for Laravel",
     "license": "MIT",
     "version": "2.1.0",

--- a/src/RobBrazier/Piwik/Piwik.php
+++ b/src/RobBrazier/Piwik/Piwik.php
@@ -449,7 +449,7 @@ class Piwik {
             case 'json':
                 $count = count($v->actionDetails) - 1; 
                 $page_link = $v->actionDetails[$count]->url;
-                $page_title = $v->actionDetails[$count]->pageTitle;
+                $page_title = isset($v->actionDetails[$count]->pageTitle) ? $v->actionDetails[$count]->pageTitle : null;
                 
                 // Get just the image names (API returns path to icons in piwik install)
                 $flag = explode('/', $v->countryFlag);


### PR DESCRIPTION
{#405 ▼
  +"type": "search"
  +"url": ""
  +"pageIdAction": null
  +"serverTimePretty": "Dec 8, 2015 5:17:53 PM"
  +"pageId": "3175"
  +"customVariables": {#406 ▶}
  +"siteSearchKeyword": "xxxYYYyxxxYY"
  +"generationTime": "0.18s"
  +"icon": "plugins/Morpheus/images/search_ico.png"
  +"timestamp": 1449595073
}