### PR TITLE
Add UserCountry and DevicesDetection Modules

### DIFF
--- a/src/RobBrazier/Piwik/Module/DevicesDetectionModule.php
+++ b/src/RobBrazier/Piwik/Module/DevicesDetectionModule.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace RobBrazier\Piwik\Module;
+
+class DevicesDetectionModule extends Module
+{
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getType($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getBrand($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getModel($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getOsFamilies($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getOsVersions($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getBrowsers($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getBrowserVersions($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getBrowserEngines($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+}

--- a/src/RobBrazier/Piwik/Module/UserCountryModule.php
+++ b/src/RobBrazier/Piwik/Module/UserCountryModule.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace RobBrazier\Piwik\Module;
+
+class UserCountryModule extends Module
+{
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getCountry($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getContinent($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getRegion($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getCity($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getCountryCodeMapping($format = null)
+    {
+        $options = $this->getOptions($format)->setArguments([]);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param string             $ip        The IP to search for a location from
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getLocationFromIP($ip, $arguments = [], $format = null)
+    {
+        $arguments += ['ip' => $ip];
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+
+    /**
+     * @param array[string]mixed $arguments extra arguments to be passed to the api call
+     * @param string             $format    override format (defaults to one specified in config file)
+     *
+     * @return mixed
+     */
+    public function getNumberOfDistinctCountries($arguments = [], $format = null)
+    {
+        $options = $this->getOptions($format)->setArguments($arguments);
+
+        return $this->request->send($options);
+    }
+}

--- a/src/RobBrazier/Piwik/Piwik.php
+++ b/src/RobBrazier/Piwik/Piwik.php
@@ -11,6 +11,7 @@ use RobBrazier\Piwik\Module\ProviderModule;
 use RobBrazier\Piwik\Module\ReferrersModule;
 use RobBrazier\Piwik\Module\SEOModule;
 use RobBrazier\Piwik\Module\SitesManagerModule;
+use RobBrazier\Piwik\Module\UserCountryModule;
 use RobBrazier\Piwik\Module\VisitorInterestModule;
 use RobBrazier\Piwik\Module\VisitsSummaryModule;
 use RobBrazier\Piwik\Module\UsersManagerModule;
@@ -205,6 +206,18 @@ class Piwik
     public function getVisitsSummary()
     {
         return new VisitsSummaryModule($this->request);
+    }
+
+    /**
+     * Initialise the UserCountryModule Module.
+     *
+     * @see https://developer.matomo.org/api-reference/reporting-api#UserCountry for arguments
+     *
+     * @return UserCountryModule
+     */
+    public function getUserCountry()
+    {
+        return new UserCountryModule($this->request);
     }
 
     /**

--- a/src/RobBrazier/Piwik/Piwik.php
+++ b/src/RobBrazier/Piwik/Piwik.php
@@ -5,6 +5,7 @@ namespace RobBrazier\Piwik;
 use RobBrazier\Piwik\Module\ActionsModule;
 use RobBrazier\Piwik\Module\APIModule;
 use RobBrazier\Piwik\Module\ContentsModule;
+use RobBrazier\Piwik\Module\DevicesDetectionModule;
 use RobBrazier\Piwik\Module\EventsModule;
 use RobBrazier\Piwik\Module\LiveModule;
 use RobBrazier\Piwik\Module\ProviderModule;
@@ -218,6 +219,18 @@ class Piwik
     public function getUserCountry()
     {
         return new UserCountryModule($this->request);
+    }
+
+    /**
+     * Initialise the DevicesDetection Module.
+     *
+     * @see https://developer.matomo.org/api-reference/reporting-api#DevicesDetection for arguments
+     *
+     * @return DevicesDetectionModule
+     */
+    public function getDevicesDetection()
+    {
+        return new DevicesDetectionModule($this->request);
     }
 
     /**

--- a/tests/RobBrazier/Piwik/Module/DevicesDetectionModuleTest.php
+++ b/tests/RobBrazier/Piwik/Module/DevicesDetectionModuleTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace RobBrazier\Piwik\Module;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
+use RobBrazier\Piwik\Repository\RequestRepository;
+use RobBrazier\Piwik\Request\RequestOptions;
+
+class DevicesDetectionModuleTest extends TestCase
+{
+    /**
+     * @var Prophet
+     */
+    private $prophet;
+
+    private $request;
+
+    /**
+     * @var DevicesDetectionModule
+     */
+    private $devicesDetection;
+
+    /**
+     * @var RequestOptions
+     */
+    private $requestOptions;
+
+    /**
+     * @var string
+     */
+    private $expectedResponse;
+
+    public function setUp(): void
+    {
+        $this->prophet = new Prophet();
+        $this->request = $this->prophet->prophesize(RequestRepository::class);
+        $this->devicesDetection = new DevicesDetectionModule($this->request->reveal());
+        $this->requestOptions = new RequestOptions();
+        $this->requestOptions
+            ->usePeriod(true)
+            ->useSiteId(true)
+            ->useFormat(true)
+            ->useTokenAuth(true);
+        $this->expectedResponse = 'foo';
+    }
+
+    public function testGetType()
+    {
+        $this->requestOptions
+            ->setMethod('DevicesDetection.getType');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->devicesDetection->getType();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetBrand()
+    {
+        $this->requestOptions
+            ->setMethod('DevicesDetection.getBrand');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->devicesDetection->getBrand();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetModel()
+    {
+        $this->requestOptions
+            ->setMethod('DevicesDetection.getModel');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->devicesDetection->getModel();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetOsFamilies()
+    {
+        $this->requestOptions
+            ->setMethod('DevicesDetection.getOsFamilies');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->devicesDetection->getOsFamilies();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetOsVersions()
+    {
+        $this->requestOptions
+            ->setMethod('DevicesDetection.getOsVersions');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->devicesDetection->getOsVersions();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetBrowsers()
+    {
+        $this->requestOptions
+            ->setMethod('DevicesDetection.getBrowsers');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->devicesDetection->getBrowsers();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetBrowserVersions()
+    {
+        $this->requestOptions
+            ->setMethod('DevicesDetection.getBrowserVersions');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->devicesDetection->getBrowserVersions();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetBrowserEngines()
+    {
+        $this->requestOptions
+            ->setMethod('DevicesDetection.getBrowserEngines');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->devicesDetection->getBrowserEngines();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+}

--- a/tests/RobBrazier/Piwik/Module/UserCountryModuleTest.php
+++ b/tests/RobBrazier/Piwik/Module/UserCountryModuleTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace RobBrazier\Piwik\Module;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
+use RobBrazier\Piwik\Repository\RequestRepository;
+use RobBrazier\Piwik\Request\RequestOptions;
+
+class UserCountryModuleTest extends TestCase
+{
+    /**
+     * @var Prophet
+     */
+    private $prophet;
+
+    private $request;
+
+    /**
+     * @var UserCountryModule
+     */
+    private $userCountry;
+
+    /**
+     * @var RequestOptions
+     */
+    private $requestOptions;
+
+    /**
+     * @var string
+     */
+    private $expectedResponse;
+
+    public function setUp(): void
+    {
+        $this->prophet = new Prophet();
+        $this->request = $this->prophet->prophesize(RequestRepository::class);
+        $this->userCountry = new UserCountryModule($this->request->reveal());
+        $this->requestOptions = new RequestOptions();
+        $this->requestOptions
+            ->usePeriod(true)
+            ->useSiteId(true)
+            ->useFormat(true)
+            ->useTokenAuth(true);
+        $this->expectedResponse = 'foo';
+    }
+
+    public function testGetCountry()
+    {
+        $this->requestOptions
+            ->setMethod('UserCountry.getCountry');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->userCountry->getCountry();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetContinent()
+    {
+        $this->requestOptions
+            ->setMethod('UserCountry.getContinent');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->userCountry->getContinent();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetRegion()
+    {
+        $this->requestOptions
+            ->setMethod('UserCountry.getRegion');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->userCountry->getRegion();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetCity()
+    {
+        $this->requestOptions
+            ->setMethod('UserCountry.getCity');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->userCountry->getCity();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetCountryCodeMapping()
+    {
+        $this->requestOptions
+            ->setMethod('UserCountry.getCountryCodeMapping');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->userCountry->getCountryCodeMapping();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetLocationFromIP()
+    {
+        $ip = 'ip';
+        $this->requestOptions
+            ->setMethod('UserCountry.getLocationFromIP')
+            ->setArguments([
+                'ip' => $ip,
+            ]);
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->userCountry->getLocationFromIP($ip);
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+
+    public function testGetNumberOfDistinctCountries()
+    {
+        $this->requestOptions
+            ->setMethod('UserCountry.getNumberOfDistinctCountries');
+        $this->request->send($this->requestOptions)->willReturn($this->expectedResponse);
+        $response = $this->userCountry->getNumberOfDistinctCountries();
+        $this->assertEquals($this->expectedResponse, $response);
+    }
+}

--- a/tests/RobBrazier/Piwik/PiwikTest.php
+++ b/tests/RobBrazier/Piwik/PiwikTest.php
@@ -14,6 +14,7 @@ use RobBrazier\Piwik\Module\ProviderModule;
 use RobBrazier\Piwik\Module\ReferrersModule;
 use RobBrazier\Piwik\Module\SEOModule;
 use RobBrazier\Piwik\Module\SitesManagerModule;
+use RobBrazier\Piwik\Module\UserCountryModule;
 use RobBrazier\Piwik\Module\VisitorInterestModule;
 use RobBrazier\Piwik\Module\VisitsSummaryModule;
 use RobBrazier\Piwik\Repository\ConfigRepository;
@@ -127,6 +128,12 @@ class PiwikTest extends TestCase
     {
         $visitsSummary = $this->piwik->getVisitsSummary();
         $this->assertInstanceOf(VisitsSummaryModule::class, $visitsSummary);
+    }
+
+    public function testGetUserCountry()
+    {
+        $userCountry = $this->piwik->getUserCountry();
+        $this->assertInstanceOf(UserCountryModule::class, $userCountry);
     }
 
     public function testGetTag()

--- a/tests/RobBrazier/Piwik/PiwikTest.php
+++ b/tests/RobBrazier/Piwik/PiwikTest.php
@@ -8,6 +8,7 @@ use RobBrazier\Piwik\Config\Option;
 use RobBrazier\Piwik\Module\ActionsModule;
 use RobBrazier\Piwik\Module\APIModule;
 use RobBrazier\Piwik\Module\ContentsModule;
+use RobBrazier\Piwik\Module\DevicesDetectionModule;
 use RobBrazier\Piwik\Module\EventsModule;
 use RobBrazier\Piwik\Module\LiveModule;
 use RobBrazier\Piwik\Module\ProviderModule;
@@ -134,6 +135,12 @@ class PiwikTest extends TestCase
     {
         $userCountry = $this->piwik->getUserCountry();
         $this->assertInstanceOf(UserCountryModule::class, $userCountry);
+    }
+
+    public function testGetDevicesDetection()
+    {
+        $devicesDetection = $this->piwik->getDevicesDetection();
+        $this->assertInstanceOf(DevicesDetectionModule::class, $devicesDetection);
     }
 
     public function testGetTag()


### PR DESCRIPTION
Not sure if these were left out of the package for a reason but I needed them for a project I'm working on anyway, so if useful feel free to accept this pull request. 

Adds the UserCountry (https://developer.matomo.org/api-reference/reporting-api#UserCountry) and DevicesDetection (https://developer.matomo.org/api-reference/reporting-api#DevicesDetection) modules. 

Tests for both are included following the structure used in the rest of the package. 

Thanks!